### PR TITLE
devices/visionfive-2: adapt for /boot as ext4

### DIFF
--- a/devices/starfive/visionfive-2/apply-bootloader.bash
+++ b/devices/starfive/visionfive-2/apply-bootloader.bash
@@ -1,16 +1,7 @@
 #!/bin/bash
 
-case "$DEVICE_ID" in
-	visionfive-2)
-	DTB_NAME=jh7110-starfive-visionfive-2-v1.3b
-	;;
-	*)
-	DTB_NAME=jh7110-starfive-visionfive-2-v1.2a
-	;;
-esac
-
-echo "Generating uEnv.txt ..."
-cat > /boot/u-boot/uEnv.txt <<- EOF
+echo "Generating vf2_uEnv.txt ..."
+cat > /efi/vf2_uEnv.txt <<- EOF
 	fdt_high=0xffffffffffffffff
 	initrd_high=0xffffffffffffffff
 	kernel_addr_r=0x40200000
@@ -18,12 +9,7 @@ cat > /boot/u-boot/uEnv.txt <<- EOF
 	kernel_comp_size=0x4000000
 	fdt_addr_r=0x46000000
 	ramdisk_addr_r=0x46100000
-	#Move distro to first boot to speed up booting
-	boot_targets=distro mmc0 dhcp
-	#Fix wrong fdtfile name
-	fdtfile=starfive/${DTB_NAME}.dtb
-	#Fix missing bootcmd
-	bootcmd=run load_distro_uenv;run bootcmd_distro
+	boot2=if test \${chip_vision} = B; then setenv fdtfile starfive/jh7110-starfive-visionfive-2-v1.3b.dtb; else setenv fdtfile starfive/jh7110-starfive-visionfive-2-v1.2a.dtb; fi; sysboot \${bootdev} \${devnum}:4 any \${scriptaddr} /extlinux/extlinux.conf
 EOF
 
 echo "Configuring U-Boot ..."
@@ -35,6 +21,6 @@ cat > /etc/default/u-boot <<- EOF
 	U_BOOT_SYNC_DTBS=true
 EOF
 
-echo "Syncing dtbs to /boot/u-boot ..."
+echo "Syncing dtbs to /boot ..."
 _KERNEL=$(ls boot/vmlinux-* | sed 's#boot/vmlinux-##')
 /etc/kernel/postinst.d/zz-u-boot-menu ${_KERNEL}

--- a/devices/starfive/visionfive-2/device.toml
+++ b/devices/starfive/visionfive-2/device.toml
@@ -13,12 +13,12 @@ bsp_packages = [
 
 kernel_cmdline = ["rw", "console=tty0", "console=ttyS0,115200", "earlycon", "rootwait", "stmmaceth=chain_mode:1", "selinux=0"]
 partition_map = "gpt"
-num_partitions = 4
+num_partitions = 5
 
 [size]
-base = 6144
+base = 7400
 desktop = 25000
-server = 6144
+server = 7400
 
 # U-Boot SPL
 [[partition]]
@@ -42,12 +42,20 @@ filesystem = "none"
 num = 3
 type = "esp"
 usage = "boot"
-size_in_sectors = 307200
+size_in_sectors = 32768
 filesystem = "fat32"
-mountpoint = "/boot/u-boot"
+mountpoint = "/efi"
 
 [[partition]]
 num = 4
+type = "linux"
+usage = "boot"
+size_in_sectors = 4194304
+filesystem = "ext4"
+mountpoint = "/boot"
+
+[[partition]]
+num = 5
 type = "linux"
 usage = "rootfs"
 size_in_sectors = 0


### PR DESCRIPTION
As the changes in u-boot-menu for /boot/u-boot is reverted, adapt the visionfive-2 bootchain for /boot as ext4 instead.

Add a VFAT partition to store the environment override, which is required to be the 3rd part on VisionFive 2 (the 1st on the stock bootloader of Orange Pi RV).